### PR TITLE
copy of databricks notebooks

### DIFF
--- a/analytics/dbrks_gp_practices_it_standards/dbrks_primarycare_gp_it_standards_year_count_prop.py
+++ b/analytics/dbrks_gp_practices_it_standards/dbrks_primarycare_gp_it_standards_year_count_prop.py
@@ -1,0 +1,92 @@
+# Databricks notebook source
+#!/usr/bin python3
+
+# -------------------------------------------------------------------------
+# Copyright (c) 2021 NHS England and NHS Improvement. All rights reserved.
+# Licensed under the MIT License. See license.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+"""
+FILE:           dbrks_primarycare_gp_it_standards_year_count_prop.py
+DESCRIPTION:
+                Databricks notebook with processing code for the NHSX Analyticus unit metric: No. and % of GP practices compliant with IT standards (GPITOM) (M074)
+USAGE:
+                ...
+CONTRIBUTORS:   Mattia Ficarelli
+CONTACT:        data@nhsx.nhs.uk
+CREATED:        15 Jan 2021
+VERSION:        0.0.1
+"""
+
+# COMMAND ----------
+
+# Install libs
+# -------------------------------------------------------------------------
+%pip install geojson==2.5.* tabulate requests pandas pathlib azure-storage-file-datalake beautifulsoup4 numpy urllib3 lxml regex pyarrow==5.0.*
+
+# COMMAND ----------
+
+# Imports
+# -------------------------------------------------------------------------
+# Python:
+import os
+import io
+import tempfile
+from datetime import datetime
+import json
+
+# 3rd party:
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from azure.storage.filedatalake import DataLakeServiceClient
+
+# Connect to Azure datalake
+# -------------------------------------------------------------------------
+# !env from databricks secrets
+CONNECTION_STRING = dbutils.secrets.get(scope="datalakefs", key="CONNECTION_STRING")
+
+# COMMAND ----------
+
+# MAGIC %run /Repos/prod/au-azure-databricks/functions/dbrks_helper_functions
+
+# COMMAND ----------
+
+# Load JSON config from Azure datalake
+# -------------------------------------------------------------------------
+file_path_config = "/config/pipelines/nhsx-au-analytics/"
+file_name_config = "config_gp_it_standards_dbrks.json"
+file_system_config = "nhsxdatalakesagen2fsprod"
+config_JSON = datalake_download(CONNECTION_STRING, file_system_config, file_path_config, file_name_config)
+config_JSON = json.loads(io.BytesIO(config_JSON).read())
+
+# COMMAND ----------
+
+# Read parameters from JSON config
+# -------------------------------------------------------------------------
+source_path = config_JSON['pipeline']['project']['source_path']
+source_file = config_JSON['pipeline']['project']['source_file']
+file_system = config_JSON['pipeline']['adl_file_system']
+sink_path = config_JSON['pipeline']['project']["databricks"][1]['sink_path']
+sink_file = config_JSON['pipeline']['project']["databricks"][1]['sink_file']
+
+# COMMAND ----------
+
+# Processing
+# -------------------------------------------------------------------------
+latestFolder = datalake_latestFolder(CONNECTION_STRING, file_system, source_path)
+file = datalake_download(CONNECTION_STRING, file_system, source_path+latestFolder, source_file)
+df = pd.read_parquet(io.BytesIO(file), engine = 'pyarrow')
+df1 = df.rename(columns = {"Practice ODS Code": "Practice code", "FULLY COMPLIANT": "GP practice compliance with IT standards"})
+df1["GP practice compliance with IT standards"] = df1["GP practice compliance with IT standards"].replace("YES", 1).replace("NO", 0)
+df1.index.name = "Unique ID"
+df_processed = df1.copy()
+
+# COMMAND ----------
+
+# Upload processed data to datalake
+# -------------------------------------------------------------------------
+file_contents = io.StringIO()
+df_processed.to_csv(file_contents)
+datalake_upload(file_contents, CONNECTION_STRING, file_system, sink_path+latestFolder, sink_file)

--- a/analytics/dbrks_gp_practices_it_standards/dbrks_primarycare_gp_it_standards_year_prop.py
+++ b/analytics/dbrks_gp_practices_it_standards/dbrks_primarycare_gp_it_standards_year_prop.py
@@ -1,0 +1,95 @@
+# Databricks notebook source
+#!/usr/bin python3
+
+# -------------------------------------------------------------------------
+# Copyright (c) 2021 NHS England and NHS Improvement. All rights reserved.
+# Licensed under the MIT License. See license.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+"""
+FILE:           dbrks_primarycare_gp_it_standards_month_prop.py
+DESCRIPTION:
+                Databricks notebook with processing code for the NHSX Analyticus unit metric: Proportion of GP practices compliant with IT standards (*Cyber Security) (M015)
+USAGE:
+                ...
+CONTRIBUTORS:   Craig Shenton, Mattia Ficarelli ,Everistus Oputa
+CONTACT:        data@nhsx.nhs.uk
+CREATED:        23 Nov 2021
+VERSION:        0.0.1
+"""
+
+# COMMAND ----------
+
+# Install libs
+# -------------------------------------------------------------------------
+%pip install geojson==2.5.* tabulate requests pandas pathlib azure-storage-file-datalake beautifulsoup4 numpy urllib3 lxml regex pyarrow==5.0.*
+
+# COMMAND ----------
+
+# Imports
+# -------------------------------------------------------------------------
+# Python:
+import os
+import io
+import tempfile
+from datetime import datetime
+import json
+
+# 3rd party:
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from azure.storage.filedatalake import DataLakeServiceClient
+
+# Connect to Azure datalake
+# -------------------------------------------------------------------------
+# !env from databricks secrets
+CONNECTION_STRING = dbutils.secrets.get(scope="datalakefs", key="CONNECTION_STRING")
+
+# COMMAND ----------
+
+# MAGIC %run /Repos/prod/au-azure-databricks/functions/dbrks_helper_functions
+
+# COMMAND ----------
+
+# Load JSON config from Azure datalake
+# -------------------------------------------------------------------------
+file_path_config = "/config/pipelines/nhsx-au-analytics/"
+file_name_config = "config_gp_it_standards_dbrks.json"
+file_system_config = "nhsxdatalakesagen2fsprod"
+config_JSON = datalake_download(CONNECTION_STRING, file_system_config, file_path_config, file_name_config)
+config_JSON = json.loads(io.BytesIO(config_JSON).read())
+
+# COMMAND ----------
+
+# Read parameters from JSON config
+# -------------------------------------------------------------------------
+source_path = config_JSON['pipeline']['project']['source_path']
+source_file = config_JSON['pipeline']['project']['source_file']
+file_system = config_JSON['pipeline']['adl_file_system']
+sink_path = config_JSON['pipeline']['project']['databricks'][0]['sink_path']
+sink_file = config_JSON['pipeline']['project']['databricks'][0]['sink_file']  
+
+# COMMAND ----------
+
+# Processing
+# -------------------------------------------------------------------------
+latestFolder = datalake_latestFolder(CONNECTION_STRING, file_system, source_path)
+file = datalake_download(CONNECTION_STRING, file_system, source_path+latestFolder, source_file)
+df = pd.read_parquet(io.BytesIO(file),engine = 'pyarrow')
+df1 = df.rename(columns = {"Practice ODS Code": "Practice code", "FULLY COMPLIANT": "GP practice compliance with IT standards"})
+df1["GP practice compliance with IT standards"] = df1["GP practice compliance with IT standards"].replace("YES", 1).replace("NO", 0)
+df2 = df1.groupby(["Date","Financial Year"]).agg({"GP practice compliance with IT standards": "sum", "Practice code":"count"}).reset_index()
+df3 = df2.rename(columns  = {"GP practice compliance with IT standards": "Number of GP practices compliant with IT standards", "Practice code": "Number of GP practices"})
+df3['Percentage of GP practices compliant with IT standards'] = (df3["Number of GP practices compliant with IT standards"]/df3["Number of GP practices"]).round(4)
+df3.index.name = "Unique ID"
+df_processed = df3.copy()
+
+# COMMAND ----------
+
+# Upload processed data to datalake
+# -------------------------------------------------------------------------
+file_contents = io.StringIO()
+df_processed.to_csv(file_contents)
+datalake_upload(file_contents, CONNECTION_STRING, file_system, sink_path+latestFolder, sink_file)

--- a/analytics/dbrks_gp_records_api/dbrks_primarycare_gp_records_api_month_count.py
+++ b/analytics/dbrks_gp_records_api/dbrks_primarycare_gp_records_api_month_count.py
@@ -1,0 +1,115 @@
+# Databricks notebook source
+#!/usr/bin python3
+
+# -------------------------------------------------------------------------
+# Copyright (c) 2021 NHS England and NHS Improvement. All rights reserved.
+# Licensed under the MIT License. See license.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+"""
+FILE:           dbrks_primarycare_gp_records_api_month_count.py
+DESCRIPTION:
+                Databricks notebook with processing code for the NHSX Analyticus unit metric: Number of GP records accessed using the digital API* by other NHS organisations (* Direct Care API) (M016)
+USAGE:
+                ...
+CONTRIBUTORS:   Craig Shenton, Mattia Ficarelli
+CONTACT:        data@nhsx.nhs.uk
+CREATED:        23 Nov 2021
+VERSION:        0.0.1
+"""
+
+# COMMAND ----------
+
+# Install libs
+# -------------------------------------------------------------------------
+%pip install geojson==2.5.* tabulate requests pandas pathlib azure-storage-file-datalake beautifulsoup4 numpy urllib3 lxml regex pyarrow==5.0.*
+
+# COMMAND ----------
+
+# Imports
+# -------------------------------------------------------------------------
+# Python:
+import os
+import io
+import tempfile
+from datetime import datetime
+import json
+
+# 3rd party:
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from azure.storage.filedatalake import DataLakeServiceClient
+
+# Connect to Azure datalake
+# -------------------------------------------------------------------------
+# !env from databricks secrets
+CONNECTION_STRING = dbutils.secrets.get(scope="datalakefs", key="CONNECTION_STRING")
+
+# COMMAND ----------
+
+# MAGIC %run /Repos/prod/au-azure-databricks/functions/dbrks_helper_functions
+
+# COMMAND ----------
+
+# Load JSON config from Azure datalake
+# -------------------------------------------------------------------------
+file_path_config = "/config/pipelines/nhsx-au-analytics/"
+file_name_config = "config_gp_records_api_dbrks.json"
+file_system_config = "nhsxdatalakesagen2fsprod"
+config_JSON = datalake_download(CONNECTION_STRING, file_system_config, file_path_config, file_name_config)
+config_JSON = json.loads(io.BytesIO(config_JSON).read())
+
+# COMMAND ----------
+
+# Read parameters from JSON config
+# -------------------------------------------------------------------------
+source_path = config_JSON['pipeline']['project']['source_path']
+source_file = config_JSON['pipeline']['project']['source_file']
+file_system = config_JSON['pipeline']['adl_file_system']
+sink_path = config_JSON['pipeline']['project']['sink_path']
+sink_file = config_JSON['pipeline']['project']['sink_file']  
+
+# COMMAND ----------
+
+# Processing
+# -------------------------------------------------------------------------
+latestFolder = datalake_latestFolder(CONNECTION_STRING, file_system, source_path)
+file = datalake_download(CONNECTION_STRING, file_system, source_path+latestFolder, source_file)
+df = pd.read_csv(io.BytesIO(file))
+df1 = df.drop([
+        'Number of GP Practices in England enabled to share records', 
+        'Percent of GP Practices in England enabled to share records',
+        'Number of appointments booked for patients',
+        'Number of GP practices in England engaged in an appointment transaction',
+        'Percent of GP practices in England engaged in an appointment transaction',
+        'Number of GP practices in England that have been enabled to share appointments',
+        'Percent of GP practices in England that have been enabled to share appointments',
+        'Unique ID'
+        ], 
+        axis=1
+    )
+df1['Date of extract'] = pd.to_datetime(df1['Date of extract'])
+df1 = df1.rename(columns = {'Date of extract': 'Date'})
+df2 = df1.copy()
+df3 = df2.set_index('Date')
+resampled_date_list = []
+resampled_date_df = pd.DataFrame()
+resampled_date_list = df3.groupby(df3.index.month).apply(lambda x: x.index.max())
+resampled_date_df['Date'] = resampled_date_list 
+resampled_date_df = resampled_date_df.reset_index(drop = True)
+resampled_date_df_1 = resampled_date_df.merge(df1, how='left', on='Date')
+resampled_date_df_1 = resampled_date_df_1.sort_values(by='Date', ascending=True).reset_index(drop = True)
+df4 = resampled_date_df_1.rename(columns = {'Date of extract': 'Date', 'Number of patient records viewed': 'Number of GP records accessed using the digital API'})
+df4['Date'] = df4['Date'].dt.strftime("%Y-%m")
+df4.index.name = "Unique ID"
+df_processed = df4.copy()
+
+# COMMAND ----------
+
+# Upload processed data to datalake
+# -------------------------------------------------------------------------
+file_contents = io.StringIO()
+df_processed.to_csv(file_contents)
+datalake_upload(file_contents, CONNECTION_STRING, file_system, sink_path+latestFolder, sink_file)

--- a/analytics/dbrks_open_repos/dbrks_analytics_github_gitlab_openrepos_month_count.py
+++ b/analytics/dbrks_open_repos/dbrks_analytics_github_gitlab_openrepos_month_count.py
@@ -1,0 +1,90 @@
+# Databricks notebook source
+#!/usr/bin python3
+
+# -------------------------------------------------------------------------
+# Copyright (c) 2021 NHS England and NHS Improvement. All rights reserved.
+# Licensed under the MIT License. See license.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+"""
+FILE:           analytics_github_gitlab_openrepos_month_count.py
+DESCRIPTION:
+                Databricks notebook with processing code for the NHSX Analyticus unit metric: Number of health and care projects shared in open repositories (M027)
+USAGE:
+                ...
+CONTRIBUTORS:   Craig Shenton, Mattia Ficarelli
+CONTACT:        data@nhsx.nhs.uk
+CREATED:        24 Nov 2021
+VERSION:        0.0.1
+"""
+
+# COMMAND ----------
+
+# Install libs
+# -------------------------------------------------------------------------
+%pip install geojson==2.5.* tabulate requests pandas pathlib azure-storage-file-datalake beautifulsoup4 numpy urllib3 lxml regex pyarrow==5.0.*
+
+# COMMAND ----------
+
+# Imports
+# -------------------------------------------------------------------------
+# Python:
+import os
+import io
+import tempfile
+from datetime import datetime
+import json
+
+# 3rd party:
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from azure.storage.filedatalake import DataLakeServiceClient
+
+# Connect to Azure datalake
+# -------------------------------------------------------------------------
+# !env from databricks secrets
+CONNECTION_STRING = dbutils.secrets.get(scope="datalakefs", key="CONNECTION_STRING")
+
+# COMMAND ----------
+
+# MAGIC %run /Repos/prod/au-azure-databricks/functions/dbrks_helper_functions
+
+# COMMAND ----------
+
+# Load JSON config from Azure datalake
+# -------------------------------------------------------------------------
+file_path_config = "/config/pipelines/nhsx-au-analytics/"
+file_name_config = "config_openrepos_dbrks.json"
+file_system_config = "nhsxdatalakesagen2fsprod"
+config_JSON = datalake_download(CONNECTION_STRING, file_system_config, file_path_config, file_name_config)
+config_JSON = json.loads(io.BytesIO(config_JSON).read())
+
+# COMMAND ----------
+
+# Read parameters from JSON config
+# -------------------------------------------------------------------------
+file_system = config_JSON['pipeline']['adl_file_system']
+source_path = config_JSON['pipeline']['project']['source_path']
+source_file = config_JSON['pipeline']['project']['source_file']
+sink_path = config_JSON['pipeline']['project']['sink_path']
+sink_file = config_JSON['pipeline']['project']['sink_file']  
+
+# COMMAND ----------
+
+# Processing
+# -------------------------------------------------------------------------
+latestFolder = datalake_latestFolder(CONNECTION_STRING, file_system, source_path)
+file = datalake_download(CONNECTION_STRING, file_system, source_path+latestFolder, source_file)
+df = pd.read_csv(io.BytesIO(file))
+df1 = df.set_index('Unique ID')
+df_processed = df1.copy()
+
+# COMMAND ----------
+
+# Upload processed data to datalake
+# -------------------------------------------------------------------------
+file_contents = io.StringIO()
+df_processed.to_csv(file_contents)
+datalake_upload(file_contents, CONNECTION_STRING, file_system, sink_path+latestFolder, sink_file)

--- a/ingestion/dbrks_gp_practices_it_standards/dbrks_gp_it_standards_raw.py
+++ b/ingestion/dbrks_gp_practices_it_standards/dbrks_gp_it_standards_raw.py
@@ -1,0 +1,123 @@
+# Databricks notebook source
+#!/usr/bin python3
+
+# -------------------------------------------------------------------------
+# Copyright (c) 2021 NHS England and NHS Improvement. All rights reserved.
+# Licensed under the MIT License. See license.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+"""
+FILE:           dbrks_gp_it_standards_raw.py
+DESCRIPTION:
+                Databricks notebook with code to append new raw data to historical
+                data for the NHSX Analyticus unit metrics within the GP IT standards topic
+                topic
+USAGE:
+                ...
+CONTRIBUTORS:   Mattia Ficarelli
+CONTACT:        data@nhsx.nhs.uk
+CREATED:        01 Feb. 2021
+VERSION:        0.0.1
+"""
+
+# COMMAND ----------
+
+# Install libs
+# ------------------------------------------------------------------------------------
+%pip install pandas pathlib azure-storage-file-datalake numpy pyarrow==5.0.*
+
+# COMMAND ----------
+
+# Imports
+# -------------------------------------------------------------------------
+# Python:
+import os
+import io
+import tempfile
+from datetime import datetime
+import json
+
+# 3rd party:
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from azure.storage.filedatalake import DataLakeServiceClient
+
+# Connect to Azure datalake
+# -------------------------------------------------------------------------
+# !env from databricks secrets
+CONNECTION_STRING = dbutils.secrets.get(scope="datalakefs", key="CONNECTION_STRING")
+
+# COMMAND ----------
+
+# MAGIC %run /Repos/prod/au-azure-databricks/functions/dbrks_helper_functions
+
+# COMMAND ----------
+
+# Load JSON config from Azure datalake
+# -------------------------------------------------------------------------
+file_path_config = "/config/pipelines/nhsx-au-analytics/"
+file_name_config = "config_gp_it_standards_dbrks.json"
+file_system_config = "nhsxdatalakesagen2fsprod"
+config_JSON = datalake_download(CONNECTION_STRING, file_system_config, file_path_config, file_name_config)
+config_JSON = json.loads(io.BytesIO(config_JSON).read())
+
+# COMMAND ----------
+
+# Read parameters from JSON config
+# -------------------------------------------------------------------------
+file_system = config_JSON['pipeline']['adl_file_system']
+new_source_path = config_JSON['pipeline']['raw']['snapshot_source_path']
+historical_source_path = config_JSON['pipeline']['raw']['appended_path']
+historical_source_file = config_JSON['pipeline']['raw']['appended_file']
+sink_path = config_JSON['pipeline']['raw']['appended_path']
+sink_file = config_JSON['pipeline']['raw']['appended_file']
+
+# COMMAND ----------
+
+# Pull new snapshot dataset
+# -------------------------
+latestFolder = datalake_latestFolder(CONNECTION_STRING, file_system, new_source_path)
+file_name_list = datalake_listContents(CONNECTION_STRING, file_system, new_source_path+latestFolder)
+file_name_list = [file for file in file_name_list if '.csv' in file]
+for new_source_file in file_name_list:
+  new_dataset = datalake_download(CONNECTION_STRING, file_system, new_source_path+latestFolder, new_source_file)
+  new_dataframe = pd.read_csv(io.BytesIO(new_dataset)) #------- Check if file is in .csv format. Please see SOP.
+  new_dataframe["Financial Year"] = "2020/2021" #----------- Change values year-on-year to the correct financial year. Please see SOP.
+  new_dataframe["Date"] = new_dataframe["Financial Year"].unique().tolist()[0][5:9]+"-01-01"
+
+# COMMAND ----------
+
+# Processing
+# -------------------------------------------------------------------------
+# Latest data processing
+new_dataframe = new_dataframe.rename(columns = {"Practice ODS code": "Practice ODS Code"}) #------ Rename columns so that they align to the historical dataset. Please see SOP.
+df_processed = new_dataframe[new_dataframe["Practice ODS Code"].str.contains("Grand Total")==False] #------ Check a total has not been added to the file. Please see SOP.
+
+# COMMAND ----------
+
+# Pull historical dataset
+latestFolder_historical = datalake_latestFolder(CONNECTION_STRING, file_system, historical_source_path)
+historical_dataset = datalake_download(CONNECTION_STRING, file_system, historical_source_path+latestFolder_historical, historical_source_file)
+historical_dataframe = pd.read_parquet(io.BytesIO(historical_dataset), engine="pyarrow")
+
+# Append new data to historical data
+# -----------------------------------------------------------------------
+years_in_historical = historical_dataframe["Date"].unique().tolist()
+years_in_new = df_processed["Date"].unique().tolist()[0]
+if years_in_new in years_in_historical:
+  print('Data already exists in historical data')
+else:
+  historical_dataframe = historical_dataframe.append(df_processed)
+  historical_dataframe = historical_dataframe.sort_values(by=['Date'])
+  historical_dataframe = historical_dataframe.reset_index(drop=True)
+  historical_dataframe = historical_dataframe.astype(str)
+
+# COMMAND ----------
+
+# Upload processed data to datalake
+current_date_path = datetime.now().strftime('%Y-%m-%d') + '/'
+file_contents = io.BytesIO()
+historical_dataframe.to_parquet(file_contents, engine="pyarrow")
+datalake_upload(file_contents, CONNECTION_STRING, file_system, sink_path+current_date_path, sink_file)

--- a/ingestion/dbrks_gp_records_api/dbrks_gp_records_api_raw.py
+++ b/ingestion/dbrks_gp_records_api/dbrks_gp_records_api_raw.py
@@ -1,0 +1,139 @@
+# Databricks notebook source
+#!/usr/bin python3
+
+# -------------------------------------------------------------------------
+# Copyright (c) 2021 NHS England and NHS Improvement. All rights reserved.
+# Licensed under the MIT License. See license.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+"""
+FILE:           dbrks_gp_records_api_raw.py
+DESCRIPTION:
+                Databricks notebook with code to append new raw data to historical
+                data for the NHSX Analyticus unit metrics within the topic GP Records
+USAGE:
+                ...
+CONTRIBUTORS:   Craig Shenton, Mattia Ficarelli
+CONTACT:        data@nhsx.nhs.uk
+CREATED:        18 Oct. 2021
+VERSION:        0.0.2
+"""
+
+# COMMAND ----------
+
+# Install libs
+# -------------------------------------------------------------------------
+%pip install geojson==2.5.* tabulate requests pandas pathlib azure-storage-file-datalake beautifulsoup4 numpy urllib3 lxml dateparser regex pyarrow==5.0.*
+
+# COMMAND ----------
+
+# Imports
+# -------------------------------------------------------------------------
+# Python:
+import os
+import io
+import tempfile
+from datetime import datetime
+import json
+
+# 3rd party:
+import pandas as pd
+import numpy as np
+import requests
+import urllib.request
+from pathlib import Path
+from urllib import request as urlreq
+from bs4 import BeautifulSoup
+from dateparser.search import search_dates
+from azure.storage.filedatalake import DataLakeServiceClient
+
+# Connect to Azure datalake
+# -------------------------------------------------------------------------
+# !env from databricks secrets
+CONNECTION_STRING = dbutils.secrets.get(scope="datalakefs", key="CONNECTION_STRING")
+
+# COMMAND ----------
+
+# MAGIC %run /Repos/prod/au-azure-databricks/functions/dbrks_helper_functions
+
+# COMMAND ----------
+
+# Load JSON config from Azure datalake
+# -------------------------------------------------------------------------
+file_path_config = "/config/pipelines/nhsx-au-analytics/"
+file_name_config = "config_gp_records_api_dbrks.json"
+file_system_config = "nhsxdatalakesagen2fsprod"
+config_JSON = datalake_download(CONNECTION_STRING, file_system_config, file_path_config, file_name_config)
+config_JSON = json.loads(io.BytesIO(config_JSON).read())
+
+# COMMAND ----------
+
+# Read parameters from JSON config
+# -------------------------------------------------------------------------
+file_system = config_JSON['pipeline']['adl_file_system']
+historical_source_path = config_JSON['pipeline']['raw']['source_path']
+historical_source_file = config_JSON['pipeline']['raw']['source_file']
+sink_path = config_JSON['pipeline']['raw']['appended_path']
+sink_file = config_JSON['pipeline']['raw']['appended_file']
+
+# COMMAND ----------
+
+# Scrape new data from NHS Digital webpage
+# -----------------------------------------------------------------------
+url = "https://digital.nhs.uk/services/gp-connect/deployment-and-utilisation"
+response = urllib.request.urlopen(url)
+soup = BeautifulSoup(response.read(), "lxml")
+date_data = soup.find(lambda tag:tag.name=="p" and "current as of" in tag.text)
+latestDate = search_dates(date_data.text)
+date = latestDate[0][1].strftime("%Y-%m-%d")
+results = []
+for pp in soup.select("div.nhsd-m-infographic__headline-box"):
+  ptext = (
+    pp.text.replace(",", "")
+      .replace("%", "")
+      .replace("(", " ")
+      .replace(")", " ")
+       )
+  res = [int(i) for i in ptext.split() if i.isdigit()]
+  results = results + res
+del results[-4:]
+results.append(date)
+df_new = pd.DataFrame([results])
+df_new.columns = [
+            "Number of patient records viewed",
+            "Number of GP Practices in England enabled to share records",
+            "Percent of GP Practices in England enabled to share records",
+            "Number of appointments booked for patients",
+            "Number of GP practices in England engaged in an appointment transaction",
+            "Percent of GP practices in England engaged in an appointment transaction",
+            "Number of GP practices in England that have been enabled to share appointments",
+            "Percent of GP practices in England that have been enabled to share appointments",
+            "Date of extract",
+        ]
+
+# COMMAND ----------
+
+# Pull historical dataset
+# -----------------------------------------------------------------------
+latestFolder = datalake_latestFolder(CONNECTION_STRING, file_system, historical_source_path)
+historical_dataset = datalake_download(CONNECTION_STRING, file_system, historical_source_path+latestFolder, historical_source_file)
+historical_dataframe = pd.read_csv(io.BytesIO(historical_dataset), index_col = 0)
+historical_dataframe['Date of extract'] = pd.to_datetime(historical_dataframe['Date of extract']).dt.strftime('%Y-%m-%d')
+
+# Append new data to historical data
+# -----------------------------------------------------------------------
+if date not in historical_dataframe["Date of extract"].values:
+  historical_dataframe = historical_dataframe.append(df_new)
+  historical_dataframe = historical_dataframe.reset_index(drop=True)
+  historical_dataframe.index.name = "Unique ID"
+else:
+  print('data already exists')
+
+# COMMAND ----------
+
+# Upload hsitorical appended data to datalake
+current_date_path = datetime.now().strftime('%Y-%m-%d') + '/'
+file_contents = io.StringIO()
+historical_dataframe.to_csv(file_contents)
+datalake_upload(file_contents, CONNECTION_STRING, file_system, sink_path+current_date_path, sink_file)

--- a/ingestion/dbrks_open_repos/dbrks_analytics_github_gitlab_openrepos_raw.py
+++ b/ingestion/dbrks_open_repos/dbrks_analytics_github_gitlab_openrepos_raw.py
@@ -1,0 +1,215 @@
+# Databricks notebook source
+#!/usr/bin python3
+
+# -------------------------------------------------------------------------
+# Copyright (c) 2021 NHS England and NHS Improvement. All rights reserved.
+# Licensed under the MIT License. See license.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+"""
+FILE:           dbrks_analytics_github_gitlab_openrepos_raw.py
+DESCRIPTION:
+                Databricks notebook with code to ingest new raw data and append to historical
+                data for the NHSX Analyticus unit metric: Number of health and care projects shared in open repositories (M027)
+USAGE:
+                ...
+CONTRIBUTORS:   Craig Shenton, Mattia Ficarelli
+CONTACT:        data@nhsx.nhs.uk
+CREATED:        24 Nov. 2021
+VERSION:        0.0.1
+"""
+
+# COMMAND ----------
+
+# Install libs
+# -------------------------------------------------------------------------
+%pip install geojson==2.5.* tabulate requests pandas pathlib azure-storage-file-datalake beautifulsoup4 numpy urllib3 lxml regex pyarrow==5.0.*
+
+# COMMAND ----------
+
+# Imports
+# -------------------------------------------------------------------------
+# Python:
+import os
+import io
+import tempfile
+from datetime import datetime
+from datetime import timedelta
+import json
+
+# 3rd party:
+import time
+import pandas as pd
+import numpy as np
+import requests
+from pathlib import Path
+import urllib.request
+from urllib import request as urlreq
+from bs4 import BeautifulSoup
+from azure.storage.filedatalake import DataLakeServiceClient
+
+# Connect to Azure datalake
+# -------------------------------------------------------------------------
+# !env from databricks secrets
+CONNECTION_STRING = dbutils.secrets.get(scope="datalakefs", key="CONNECTION_STRING")
+
+# COMMAND ----------
+
+# MAGIC %run /Repos/prod/au-azure-databricks/functions/dbrks_helper_functions
+
+# COMMAND ----------
+
+# Load JSON config from Azure datalake
+# -------------------------------------------------------------------------
+file_path_config = "/config/pipelines/nhsx-au-analytics/"
+file_name_config = "config_openrepos_dbrks.json"
+file_system_config = "nhsxdatalakesagen2fsprod"
+config_JSON = datalake_download(CONNECTION_STRING, file_system_config, file_path_config, file_name_config)
+config_JSON = json.loads(io.BytesIO(config_JSON).read())
+
+# COMMAND ----------
+
+# Read parameters from JSON config
+# -------------------------------------------------------------------------
+file_system = config_JSON['pipeline']['adl_file_system']
+sink_path = config_JSON['pipeline']['raw']['sink_path']
+sink_file = config_JSON['pipeline']['raw']['sink_file']
+
+# COMMAND ----------
+
+#Ingestion of raw data from the GitHub and GitLab API
+# -------------------------------------------------------------------------
+
+github_orgs = [
+        "MHRA",
+        "publichealthengland",
+        "CQCDigital",
+        "Health-Education-England",
+        "NHS-Blood-and-Transplant",
+        "NHSDigital",
+        "nhsconnect",
+        "111Online",
+        "nhsuk",
+        "nhsengland",
+        "nice-digital",
+    ]
+df_github = pd.DataFrame()
+for org in github_orgs:
+  data = [1]
+  page = 1
+  while bool(data) is True:
+    url = (
+      "https://api.github.com/orgs/"
+      + str(org)
+      + "/repos?page="
+      + str(page)
+      + "&per_page=100"
+    )
+    response = urllib.request.urlopen(url)
+    data = json.loads(response.read())
+    flat_data = pd.json_normalize(data)
+    df_github = df_github.append(flat_data)
+    page = page + 1
+df_github["open_repos"] = 1
+df_github = df_github[
+        [
+            "owner.login",
+            "owner.html_url",
+            "created_at",
+            "open_repos"
+        ]
+    ].rename(
+        columns={
+            "owner.login": "org",
+            "owner.html_url": "link",
+            "created_at": "date"
+        }
+    )
+gitlab_groups = [2955125]
+df_gitlab = pd.DataFrame()
+for group in gitlab_groups:
+  data = [1]
+  page = 1
+  while bool(data) is True:
+    url = (
+                "https://gitlab.com/api/v4/groups/"
+                + str(group)
+                + "/projects?include_subgroups=true&page="
+                + str(page)
+                + "&per_page=100"
+            )
+    response = urllib.request.urlopen(url)
+    data = json.loads(response.read())
+    flat_data = pd.json_normalize(data)
+    df_gitlab = df_gitlab.append(flat_data)
+    page = page + 1
+    time.sleep(0.2)
+df_gitlab["org"] = df_gitlab["namespace.full_path"].apply(lambda x: x.split("/")[0])
+df_gitlab["link"] = "https://gitlab.com/" + df_gitlab["org"]
+df_gitlab["open_repos"] = 1
+df_gitlab = df_gitlab[
+        [
+            "org",
+            "link",
+            "created_at",
+            "open_repos"
+        ]
+    ].rename(
+        columns={
+            "created_at": "date"
+        }
+    )
+df_combined = pd.concat([df_github, df_gitlab]).reset_index(drop=True)
+df_combined["date"] = pd.to_datetime(df_combined["date"]).apply(
+        lambda x: x.strftime("%Y-%m")
+    )
+df_combined_sum = (
+        df_combined.groupby(["date"])
+        .sum()
+        .reset_index()
+        .rename(columns={"date": "Date", "open_repos": "Number of new open repositories"})
+    )
+df_combined_sum["Number of new open repositories"] = df_combined_sum[
+        "Number of new open repositories"
+    ].fillna(0)
+
+# COMMAND ----------
+
+#Full list of dates between first time point and last timepoint
+# --------------------------------------------------------------
+first_date = df_combined_sum["Date"].min()
+last_date = df_combined_sum["Date"].max()
+df_date_check = pd.DataFrame()
+df_date_check['Date'] = pd.date_range(first_date, last_date, freq='MS').to_period('m').astype(str)
+df_date_check_1 = pd.merge(df_date_check, df_combined_sum, on="Date", how='left').fillna(0)
+
+# COMMAND ----------
+
+#Calculate the cummulative number of repositories
+# --------------------------------------------------------------
+
+df_combined_cumsum = (
+        df_date_check_1.groupby(["Date"])
+        .sum()
+        .cumsum()
+        .reset_index()
+        .rename(
+            columns={
+                "Number of new open repositories": "Cumulative number of open repositories"
+            }
+        )
+    )
+df_combined_sum_cumssum = pd.merge(
+        df_date_check_1, df_combined_cumsum, on="Date", how="outer"
+    )
+df_combined_sum_cumssum.index.name = "Unique ID"
+df_raw = df_combined_sum_cumssum.copy()
+
+# COMMAND ----------
+
+# Upload raw data snapshot to datalake
+current_date_path = datetime.now().strftime('%Y-%m-%d') + '/'
+file_contents = io.StringIO()
+df_raw.to_csv(file_contents)
+datalake_upload(file_contents, CONNECTION_STRING, file_system, sink_path+current_date_path, sink_file)

--- a/orchestration/dbrks_gp_it_orchestrator.py
+++ b/orchestration/dbrks_gp_it_orchestrator.py
@@ -1,0 +1,72 @@
+# Databricks notebook source
+#!/usr/bin python3
+
+# -------------------------------------------------------------------------
+# Copyright (c) 2021 NHS England and NHS Improvement. All rights reserved.
+# Licensed under the MIT License. See license.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+"""
+FILE:           dbrks_gp_it_orchestrator.py
+DESCRIPTION:
+                Orchestrator databricks notebook which runs the processing notebooks for NHSX Analyticus unit metrics within the GP IT topic
+USAGE:
+                ...
+CONTRIBUTORS:   Mattia Ficarelli
+CONTACT:        data@nhsx.nhs.uk
+CREATED:        15 Jan 2022
+VERSION:        0.0.1
+"""
+
+# COMMAND ----------
+
+# Install libs
+# -------------------------------------------------------------------------
+%pip install geojson==2.5.* tabulate requests pandas pathlib azure-storage-file-datalake beautifulsoup4 numpy urllib3 lxml regex pyarrow==5.0.*
+
+# COMMAND ----------
+
+# Imports
+# -------------------------------------------------------------------------
+# Python:
+import os
+import io
+import tempfile
+from datetime import datetime
+import json
+
+# 3rd party:
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from azure.storage.filedatalake import DataLakeServiceClient
+
+# Connect to Azure datalake
+# -------------------------------------------------------------------------
+# !env from databricks secrets
+CONNECTION_STRING = dbutils.secrets.get(scope="datalakefs", key="CONNECTION_STRING")
+
+# COMMAND ----------
+
+# MAGIC %run /Repos/prod/au-azure-databricks/functions/dbrks_helper_functions
+
+# COMMAND ----------
+
+#Download JSON config from Azure datalake
+file_path_config = "/config/pipelines/nhsx-au-analytics/"
+file_name_config = "config_gp_it_standards_dbrks.json"
+file_system_config = "nhsxdatalakesagen2fsprod"
+config_JSON = datalake_download(CONNECTION_STRING, file_system_config, file_path_config, file_name_config)
+config_JSON = json.loads(io.BytesIO(config_JSON).read())
+
+# COMMAND ----------
+
+#Squentially run metric notebooks
+for index, item in enumerate(config_JSON['pipeline']['project']['databricks']): # get index of objects in JSON array
+  try:
+    notebook = config_JSON['pipeline']['project']['databricks'][index]['databricks_notebook']
+    dbutils.notebook.run(notebook, 1000) # is 1000 sec for timeout
+  except Exception as e:
+    print(e)
+    raise Exception()


### PR DESCRIPTION
Copy of databricks notebooks used in the ETL for the trigger_gp_records_api. trigger_gp_it, and trigger_open_repos pipelines